### PR TITLE
add method renderFactory

### DIFF
--- a/README.md
+++ b/README.md
@@ -121,3 +121,13 @@ var output = shallowHelpers.renderWithContext(() =>
   {here: 'is', my: 'context'}
 );
 ```
+
+### renderFactory
+Returns a method for rendering with context the component passed as a parameter. Useful for testing if
+you need a helper method for rendering your component before multiple unit tests.
+
+```javascript
+var Component = React.createClass({});
+var renderMethod = shallowHelpers.renderFactory(Component);
+var renderedComponent = renderMethod(props, context);
+```

--- a/index.js
+++ b/index.js
@@ -73,6 +73,13 @@ var shallowHelpers = module.exports = {
         shallowRenderer.render(makeComponent, context);
         return shallowRenderer.getRenderOutput();
     },
+    renderFactory: function(makeComponent) {
+        return function(props, context) {
+            return shallowHelpers.renderWithContext(function () {
+                return React.createElement(makeComponent, props);
+            }, context);
+        }
+    },
     filter: filterComponent,
     find: function () {
         return filterComponent.apply(this, arguments)[0];


### PR DESCRIPTION
@robrichard i find i'm rewriting this method https://github.com/1stdibs/1stdibs.com/blob/master/dibs/assets/js/tests/specs/newPdp/components/PdpShippingAndReturns_spec.es.js#L19 in my tests, substituting PdpShippingAndReturns with whatever component i need at the moment. 

think renderFactory would be helpful? 
