### PR TITLE
fixed component verification type

### DIFF
--- a/index.js
+++ b/index.js
@@ -85,7 +85,7 @@ var shallowHelpers = module.exports = {
         return classArr.indexOf(className) !== -1;
     },
     isType: function (component, type) {
-        return component.type === type;
+        return component && component.type === type;
     },
     findType: function (component, type) {
         return shallowHelpers.find(component, function (c) {


### PR DESCRIPTION
When one (or more) children are defined as null/false, isType doesn't verify that component exists before trying to match its type. That result with a type error result and fail to return the desired type.
Case like that can happen when:

``` javascript
<div>
    <label />
    {true ? <input /> : null}
</div>

shallowHelpers.findType(component, 'input')  // ‌TypeError: Cannot read property 'type' of null
```
