### PR TITLE
fix filter if props.children is an array and has an array at one of i…

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,7 +43,9 @@ ShallowRenderer.prototype.unmount = function unmount() {
 
 var filterComponent = function (component, predicate) {
         var i;
+        var j;
         var results = [];
+        
         if (predicate(component)) {
             results.push(component);
         }
@@ -54,6 +56,10 @@ var filterComponent = function (component, predicate) {
             }
         } else if (component && component.props && component.props.children) {
             results = results.concat(filterComponent(component.props.children, predicate));
+        } else if (Array.isArray(component)) {
+            for (j = 0; j < component.length; j++) {
+                results = results.concat(filterComponent(component[j], predicate));
+            }
         }
 
         return results;


### PR DESCRIPTION
…ts indices

for example:

childOne = [div, div]
childTwo = a

div
   {childOne}
   {childTwo}
div

is currently not working in filterComponent b/c on the first pass you'll find props.children is an array, so you'll pass down props.children[0]. then nothing will happen with that array b/c it doesn't have a props property.

@robrichard 
